### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 #######################################
 # Datatypes & Classes (KEYWORD1)
 ####################################### 
-coroutines  KEYWORD1
-CoRoutine   KEYWORD1
-Scheduler   KEYWORD1
+coroutines	KEYWORD1
+CoRoutine	KEYWORD1
+Scheduler	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-worker          KEYWORD2
-resume          KEYWORD2
-isSuspended     KEYWORD2
-awake           KEYWORD2
-suspend         KEYWORD2
+worker	KEYWORD2
+resume	KEYWORD2
+isSuspended	KEYWORD2
+awake	KEYWORD2
+suspend	KEYWORD2
 
-addCoRoutine    KEYWORD2
-removeCoRoutine KEYWORD2
-runOnce         KEYWORD2
+addCoRoutine	KEYWORD2
+removeCoRoutine	KEYWORD2
+runOnce	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords